### PR TITLE
feat: Add causal_workflow for multi-component estimators

### DIFF
--- a/R/causal_workflows.R
+++ b/R/causal_workflows.R
@@ -10,6 +10,16 @@
 #' like `add_propensity_model()` and `add_outcome_model()` to specify the
 #' analysis.
 #'
+#' @details
+#' This initial version of `causal_workflow` is designed for single-stage,
+#' point-treatment estimators with binary treatments (e.g., AIPW). The
+#' underlying architecture is designed to be extensible to more complex
+#' scenarios in future versions, including:
+#' - Multi-level categorical or continuous treatments.
+#' - More generic weighting schemes, such as inverse probability of censoring
+#'   weights.
+#' - Multi-stage dynamic treatment regimes.
+#'
 #' @param ... Additional arguments. Currently ignored.
 #'
 #' @return A `causal_workflow` object.

--- a/R/causal_workflows.R
+++ b/R/causal_workflows.R
@@ -1,0 +1,86 @@
+#' Initialize a Causal Workflow
+#'
+#' @description
+#' The `causal_workflow()` function initializes a `causal_workflow` object.
+#' This object serves as a container for the various component models
+#' required for a causal analysis, such as a propensity score model and an
+#' outcome model.
+#'
+#' The resulting `causal_workflow` object is then passed to "verb" functions
+#' like `add_propensity_model()` and `add_outcome_model()` to specify the
+#' analysis.
+#'
+#' @param ... Additional arguments. Currently ignored.
+#'
+#' @return A `causal_workflow` object.
+#' @export
+causal_workflow <- function(...) {
+  check_empty_ellipses(...)
+
+  wflow <-
+    structure(
+      list(
+        propensity_model = NULL,
+        outcome_model = NULL
+      ),
+      class = "causal_workflow"
+    )
+
+  if (causal_workflow_constr(wflow)) {
+    wflow
+  }
+}
+
+#' Add a propensity model to a causal workflow
+#'
+#' @param x A `causal_workflow` object.
+#' @param wflow A `tidymodels` `workflow` object for the propensity model.
+#'
+#' @return An updated `causal_workflow` object.
+#' @export
+add_propensity_model <- function(x, wflow) {
+  check_causal_workflow(x)
+  check_workflow(wflow)
+
+  x$propensity_model <- wflow
+
+  if (causal_workflow_constr(x)) {
+    x
+  }
+}
+
+#' Add an outcome model to a causal workflow
+#'
+#' @param x A `causal_workflow` object.
+#' @param wflow A `tidymodels` `workflow` object for the outcome model.
+#'
+#' @return An updated `causal_workflow` object.
+#' @export
+add_outcome_model <- function(x, wflow) {
+  check_causal_workflow(x)
+  check_workflow(wflow)
+
+  x$outcome_model <- wflow
+
+  if (causal_workflow_constr(x)) {
+    x
+  }
+}
+
+check_causal_workflow <- function(x, call = rlang::caller_env()) {
+  if (!inherits(x, "causal_workflow")) {
+    rlang::abort(
+      "`x` must be a `causal_workflow` object.",
+      call = call
+    )
+  }
+}
+
+check_workflow <- function(wflow, call = rlang::caller_env()) {
+  if (!inherits(wflow, "workflow")) {
+    rlang::abort(
+      "`wflow` must be a `workflow` object.",
+      call = call
+    )
+  }
+}

--- a/R/constructors.R
+++ b/R/constructors.R
@@ -12,6 +12,19 @@ data_stack_constr <- function(data_stack) {
   invisible(TRUE)
 }
 
+causal_workflow_constr <- function(causal_workflow) {
+  # check that the components are either NULL or a workflow
+  if (!is.null(causal_workflow$propensity_model)) {
+    check_inherits(causal_workflow$propensity_model, "workflow")
+  }
+
+  if (!is.null(causal_workflow$outcome_model)) {
+    check_inherits(causal_workflow$outcome_model, "workflow")
+  }
+
+  invisible(TRUE)
+}
+
 model_stack_constr <- function(model_stack) {
   check_inherits(model_stack[["coefs"]], "model_fit")
   check_inherits(model_stack[["equations"]], "list")

--- a/R/fit.R
+++ b/R/fit.R
@@ -1,0 +1,147 @@
+#' @importFrom generics fit
+#' @export
+generics::fit
+
+#' Fit a causal workflow
+#'
+#' @description
+#' `fit()` for a `causal_workflow` object performs a cross-fitted estimation
+#' of the specified causal effect (e.g., ATE). It uses out-of-sample
+#' predictions for the nuisance models (propensity and outcome models) to
+#' construct the efficient influence function, providing a robust estimate.
+#'
+#' @param object A `causal_workflow` object that has been configured with
+#'   a propensity model and an outcome model.
+#' @param data A data frame containing the training data, including the
+#'   treatment, outcome, and covariate variables.
+#' @param ... Not used.
+#'
+#' @return A `fitted_causal_workflow` object. This object contains the
+#'   fitted nuisance models (trained on the full dataset), the final point
+#'   estimate and its variance, the observation-level efficient influence
+#'   function values, and the out-of-sample nuisance predictions.
+#'
+#' @export
+fit.causal_workflow <- function(object, data, ...) {
+  # 1. Validate inputs
+  .check_fit_inputs(object, data)
+
+  # 2. Extract workflows and variable names
+  pscore_wflow <- object$propensity_model
+  outcome_wflow <- object$outcome_model
+
+  treatment_formula <- pscore_wflow$pre$actions$formula$formula
+  treatment_var <- rlang::f_lhs(treatment_formula) |> rlang::as_name()
+
+  outcome_formula <- outcome_wflow$pre$actions$formula$formula
+  outcome_var <- rlang::f_lhs(outcome_formula) |> rlang::as_name()
+
+  # Ensure treatment is a factor and get levels for counterfactual prediction
+  data[[treatment_var]] <- as.factor(data[[treatment_var]])
+  treatment_levels <- levels(data[[treatment_var]])
+
+  if (length(treatment_levels) != 2) {
+    rlang::abort("The treatment variable must have exactly two levels.")
+  }
+
+  # 3. Set up cross-fitting
+  data_with_row <- data |> dplyr::mutate(.row = dplyr::row_number())
+  folds <- rsample::vfold_cv(data_with_row)
+
+  # 4. Perform cross-fitting to get nuisance predictions
+  nuisance_preds <-
+    purrr::map_dfr(
+      folds$splits,
+      ~ .fit_predict_one_fold(
+          .x,
+          pscore_wflow = pscore_wflow,
+          outcome_wflow = outcome_wflow,
+          treatment_var = treatment_var,
+          treatment_levels = treatment_levels
+        )
+    )
+
+  # 5. Join predictions back to original data
+  data_with_preds <-
+    dplyr::left_join(data_with_row, nuisance_preds, by = ".row")
+
+  # 6. Calculate EIF
+  Y <- data_with_preds[[outcome_var]]
+  A <- as.numeric(data_with_preds[[treatment_var]]) - 1 # Assumes 0/1 coding
+  g_hat <- data_with_preds$g_hat
+  q1_hat <- data_with_preds$q1_hat
+  q0_hat <- data_with_preds$q0_hat
+
+  # AIPW EIF calculation
+  term1 <- q1_hat - q0_hat
+  term2 <- (A / g_hat) * (Y - q1_hat)
+  term3 <- ((1 - A) / (1 - g_hat)) * (Y - q0_hat)
+
+  eif_values <- term1 + term2 - term3
+
+  # 7. Calculate final estimate and variance
+  ate_estimate <- mean(eif_values, na.rm = TRUE)
+  ate_variance <- stats::var(eif_values, na.rm = TRUE) / sum(!is.na(eif_values))
+
+  # 8. Fit final models on full data
+  final_g_fit <- parsnip::fit(pscore_wflow, data = data)
+  final_q_fit <- parsnip::fit(outcome_wflow, data = data)
+
+  # 9. Construct return object
+  fitted_obj <-
+    list(
+      propensity_model_fit = final_g_fit,
+      outcome_model_fit = final_q_fit,
+      original_workflows = object,
+      estimate = ate_estimate,
+      variance = ate_variance,
+      eif = eif_values,
+      nuisance_predictions = data_with_preds |> dplyr::select(-.row)
+    )
+
+  class(fitted_obj) <- "fitted_causal_workflow"
+
+  return(fitted_obj)
+}
+
+.check_fit_inputs <- function(object, data) {
+  if (is.null(object$propensity_model) || is.null(object$outcome_model)) {
+    rlang::abort("Both a propensity model and an outcome model must be added to the workflow.")
+  }
+  if (!is.data.frame(data)) {
+    rlang::abort("`data` must be a data frame.")
+  }
+}
+
+# Helper function to process one fold of the cross-fitting procedure
+.fit_predict_one_fold <- function(split, pscore_wflow, outcome_wflow, treatment_var, treatment_levels) {
+  analysis_data <- rsample::analysis(split)
+  assessment_data <- rsample::assessment(split)
+
+  g_fit <- parsnip::fit(pscore_wflow, data = analysis_data)
+  q_fit <- parsnip::fit(outcome_wflow, data = analysis_data)
+
+  # Get propensity scores for the assessment set
+  g_preds <- predict(g_fit, new_data = assessment_data, type = "prob")
+
+  # Create counterfactual datasets for outcome prediction
+  assessment_data_a1 <- assessment_data
+  assessment_data_a1[[treatment_var]] <- factor(treatment_levels[2], levels = treatment_levels)
+
+  assessment_data_a0 <- assessment_data
+  assessment_data_a0[[treatment_var]] <- factor(treatment_levels[1], levels = treatment_levels)
+
+  # Get counterfactual outcome predictions
+  q1_preds <- predict(q_fit, new_data = assessment_data_a1)
+  q0_preds <- predict(q_fit, new_data = assessment_data_a0)
+
+  # Propensity score for the treated level (A=1)
+  pscore_col <- paste0(".pred_", treatment_levels[2])
+
+  tibble::tibble(
+    .row = assessment_data$.row,
+    g_hat = g_preds[[pscore_col]],
+    q1_hat = q1_preds$.pred,
+    q0_hat = q0_preds$.pred
+  )
+}

--- a/R/predict.R
+++ b/R/predict.R
@@ -223,6 +223,44 @@ check_fitted <- function(model_stack, call = caller_env()) {
   }
 }
 
+#' Predict from a fitted causal workflow
+#'
+#' @param object A `fitted_causal_workflow` object.
+#' @param new_data A new data frame for which to generate predictions.
+#'   Note: This is not yet used in Phase 1 but is included for API
+#'   consistency and future development.
+#' @param type A character string specifying the type of prediction to return.
+#'   Valid options are:
+#'   - `"estimate"`: (Default) The final point estimate (e.g., ATE) and
+#'     its standard error.
+#'   - `"if"`: The observation-level efficient influence function (EIF) values.
+#'   - `"components"`: The out-of-sample nuisance predictions from the
+#'     cross-fitting procedure.
+#' @param ... Not used.
+#'
+#' @return A tibble with the requested prediction type.
+#'
+#' @export
+predict.fitted_causal_workflow <- function(object, new_data = NULL, type = "estimate", ...) {
+  type <- rlang::arg_match(type, c("estimate", "if", "components"))
+
+  switch(
+    type,
+    "estimate" = {
+      tibble::tibble(
+        .pred = object$estimate,
+        .std_err = sqrt(object$variance)
+      )
+    },
+    "if" = {
+      tibble::tibble(.pred_if = object$eif)
+    },
+    "components" = {
+      object$nuisance_predictions
+    }
+  )
+}
+
 #' @importFrom generics augment
 #' @export
 generics::augment

--- a/R/tune.R
+++ b/R/tune.R
@@ -38,10 +38,8 @@ tune_grid.causal_workflow <- function(object, resamples, grid, ...) {
 
   # 3. Dispatch to the correct component
   if (is_pscore_tuning && !is_outcome_tuning) {
-    rlang::inform("Tuning the propensity model.")
     tune::tune_grid(pscore_wflow, resamples = resamples, grid = grid, ...)
   } else if (is_outcome_tuning && !is_pscore_tuning) {
-    rlang::inform("Tuning the outcome model.")
     tune::tune_grid(outcome_wflow, resamples = resamples, grid = grid, ...)
   } else if (is_pscore_tuning && is_outcome_tuning) {
     # This can happen if both have the same tunable param name, e.g. `mtry`

--- a/R/tune.R
+++ b/R/tune.R
@@ -1,0 +1,84 @@
+#' @importFrom tune tune_grid
+#' @export
+tune::tune_grid
+
+#' Tune a causal workflow component
+#'
+#' @description
+#' This method supports "greedy" hyperparameter tuning for a single component
+#' of a `causal_workflow`. It identifies which component (propensity or outcome
+#' model) the provided `grid` of hyperparameters belongs to and dispatches
+#' the tuning job to `tune::tune_grid()` for that component.
+#'
+#' @param object A `causal_workflow` object.
+#' @param resamples An `rsample` object, such as one created by `rsample::vfold_cv()`.
+#' @param grid A data frame of tuning hyperparameters, created by `dials::grid_*()`.
+#' @param ... Additional arguments passed to `tune::tune_grid()`.
+#'
+#' @return A `tune_results` object from the underlying call to `tune::tune_grid()`.
+#' The user is responsible for using this result to finalize the appropriate
+#' workflow and update the `causal_workflow` object.
+#'
+#' @export
+tune_grid.causal_workflow <- function(object, resamples, grid, ...) {
+  # 1. Validate inputs
+  .check_tune_inputs(object)
+
+  # 2. Identify which component to tune
+  pscore_wflow <- object$propensity_model
+  outcome_wflow <- object$outcome_model
+
+  pscore_params <- .get_workflow_params(pscore_wflow)
+  outcome_params <- .get_workflow_params(outcome_wflow)
+
+  grid_params <- names(grid)
+
+  is_pscore_tuning <- all(grid_params %in% pscore_params)
+  is_outcome_tuning <- all(grid_params %in% outcome_params)
+
+  # 3. Dispatch to the correct component
+  if (is_pscore_tuning && !is_outcome_tuning) {
+    rlang::inform("Tuning the propensity model.")
+    tune::tune_grid(pscore_wflow, resamples = resamples, grid = grid, ...)
+  } else if (is_outcome_tuning && !is_pscore_tuning) {
+    rlang::inform("Tuning the outcome model.")
+    tune::tune_grid(outcome_wflow, resamples = resamples, grid = grid, ...)
+  } else if (is_pscore_tuning && is_outcome_tuning) {
+    # This can happen if both have the same tunable param name, e.g. `mtry`
+    rlang::abort(
+      paste(
+        "Ambiguous tuning grid. The specified parameters exist in both the",
+        "propensity and outcome models. Phase 1 only supports tuning one",
+        "component at a time."
+      )
+    )
+  } else {
+    rlang::abort(
+      paste(
+        "The provided grid parameters do not match the tunable parameters",
+        "in either the propensity or outcome model."
+      )
+    )
+  }
+}
+
+.check_tune_inputs <- function(object) {
+  if (is.null(object$propensity_model) && is.null(object$outcome_model)) {
+    rlang::abort("The causal workflow must have at least one component model to tune.")
+  }
+}
+
+# Helper to get tunable parameter names from a workflow
+.get_workflow_params <- function(wflow) {
+  if (is.null(wflow)) {
+    return(character(0))
+  }
+
+  tunable_params <- tune::tunable(wflow)
+
+  if (nrow(tunable_params) == 0) {
+    return(character(0))
+  }
+
+  return(tunable_params$name)
+}

--- a/tests/testthat/test-causal-workflow.R
+++ b/tests/testthat/test-causal-workflow.R
@@ -1,0 +1,126 @@
+# Setup for tests
+# ------------------------------------------------------------------------------
+# Create some sample data
+set.seed(1234)
+n <- 100
+sim_data <- tibble::tibble(
+  covar1 = rnorm(n),
+  covar2 = rnorm(n),
+  treatment = rbinom(n, 1, plogis(0.5 * covar1)),
+  outcome = 10 + 2 * treatment + 5 * covar1 + 3 * covar2 + rnorm(n)
+) |>
+  dplyr::mutate(treatment = factor(treatment, levels = c(0, 1), labels = c("control", "treated")))
+
+# Define component workflows
+pscore_wflow <-
+  workflows::workflow() |>
+  workflows::add_model(parsnip::logistic_reg()) |>
+  workflows::add_formula(treatment ~ covar1 + covar2)
+
+outcome_wflow <-
+  workflows::workflow() |>
+  workflows::add_model(parsnip::linear_reg()) |>
+  workflows::add_formula(outcome ~ treatment + covar1 + covar2)
+
+# Tests for the constructor and add_* verbs
+# ------------------------------------------------------------------------------
+test_that("causal_workflow constructor works", {
+  wflow <- causal_workflow()
+  expect_s3_class(wflow, "causal_workflow")
+  expect_null(wflow$propensity_model)
+  expect_null(wflow$outcome_model)
+})
+
+test_that("add_propensity_model and add_outcome_model work", {
+  wflow <- causal_workflow() |>
+    add_propensity_model(pscore_wflow) |>
+    add_outcome_model(outcome_wflow)
+
+  expect_s3_class(wflow$propensity_model, "workflow")
+  expect_s3_class(wflow$outcome_model, "workflow")
+
+  # Test error conditions
+  expect_error(add_propensity_model(wflow, "not a workflow"))
+  expect_error(add_outcome_model(wflow, "not a workflow"))
+  expect_error(add_propensity_model("not a causal workflow", pscore_wflow))
+})
+
+# Tests for fit and predict methods
+# ------------------------------------------------------------------------------
+test_that("fit.causal_workflow and predict.fitted_causal_workflow work", {
+  skip_if_not_installed("parsnip")
+  skip_if_not_installed("recipes")
+  skip_if_not_installed("rsample")
+  skip_if_not_installed("dplyr")
+
+  aipw_spec <- causal_workflow() |>
+    add_propensity_model(pscore_wflow) |>
+    add_outcome_model(outcome_wflow)
+
+  # Test fitting
+  fitted_wflow <- fit(aipw_spec, data = sim_data)
+  expect_s3_class(fitted_wflow, "fitted_causal_workflow")
+  expect_true(!is.null(fitted_wflow$estimate))
+  expect_true(!is.null(fitted_wflow$variance))
+  expect_equal(length(fitted_wflow$eif), nrow(sim_data))
+
+  # Test prediction types
+  pred_est <- predict(fitted_wflow, type = "estimate")
+  expect_true(tibble::is_tibble(pred_est))
+  expect_equal(names(pred_est), c(".pred", ".std_err"))
+  expect_equal(nrow(pred_est), 1)
+
+  pred_if <- predict(fitted_wflow, type = "if")
+  expect_true(tibble::is_tibble(pred_if))
+  expect_equal(names(pred_if), ".pred_if")
+  expect_equal(nrow(pred_if), nrow(sim_data))
+
+  pred_comp <- predict(fitted_wflow, type = "components")
+  expect_true(tibble::is_tibble(pred_comp))
+  expect_true(all(c("g_hat", "q1_hat", "q0_hat") %in% names(pred_comp)))
+  expect_equal(nrow(pred_comp), nrow(sim_data))
+})
+
+# Tests for tuning
+# ------------------------------------------------------------------------------
+test_that("tune_grid.causal_workflow works for greedy tuning", {
+  skip_if_not_installed("dials")
+  skip_if_not_installed("tune")
+  skip_if_not_installed("ranger")
+
+  # Tunable workflow
+  pscore_wflow_tune <-
+    workflows::workflow() |>
+    workflows::add_model(
+      parsnip::logistic_reg(penalty = tune::tune()) |> parsnip::set_engine("glmnet")
+    ) |>
+    workflows::add_formula(treatment ~ covar1 + covar2)
+
+  aipw_spec_tune <- causal_workflow() |>
+    add_propensity_model(pscore_wflow_tune) |>
+    add_outcome_model(outcome_wflow)
+
+  resamples <- rsample::vfold_cv(sim_data, v = 2)
+  grid <- dials::grid_regular(dials::penalty(), levels = 2)
+
+  # Test tuning dispatch
+  tune_res <- tune::tune_grid(aipw_spec_tune, resamples = resamples, grid = grid)
+  expect_s3_class(tune_res, "tune_results")
+
+  # Test error for ambiguous grid
+  outcome_wflow_tune <-
+    workflows::workflow() |>
+    workflows::add_model(
+      parsnip::linear_reg(penalty = tune::tune()) |> parsnip::set_engine("glmnet")
+    ) |>
+    workflows::add_formula(outcome ~ treatment + covar1 + covar2)
+
+  aipw_spec_ambiguous <- causal_workflow() |>
+    add_propensity_model(pscore_wflow_tune) |>
+    add_outcome_model(outcome_wflow_tune)
+
+  expect_error(
+    tune::tune_grid(aipw_spec_ambiguous, resamples = resamples, grid = grid),
+    "Ambiguous tuning grid"
+  )
+})

--- a/tests/testthat/test-causal-workflow.R
+++ b/tests/testthat/test-causal-workflow.R
@@ -3,10 +3,11 @@
 # Create some sample data
 set.seed(1234)
 n <- 100
+treatment_coef <- 0.5
 sim_data <- tibble::tibble(
   covar1 = rnorm(n),
   covar2 = rnorm(n),
-  treatment = rbinom(n, 1, plogis(0.5 * covar1)),
+  treatment = rbinom(n, 1, plogis(treatment_coef * covar1)),
   outcome = 10 + 2 * treatment + 5 * covar1 + 3 * covar2 + rnorm(n)
 ) |>
   dplyr::mutate(treatment = factor(treatment, levels = c(0, 1), labels = c("control", "treated")))


### PR DESCRIPTION
This commit introduces the initial implementation of the `causal_workflow` object, a new S3 class designed to integrate multi-component estimators (e.g., AIPW) into the tidymodels ecosystem.

This work is part of a larger effort to build the `causalmodels` package and is implemented within a fork of the `stacks` package, preserving all existing functionality.

Key features added:
- `causal_workflow()`: A constructor for the new container object.
- `add_propensity_model()` and `add_outcome_model()`: Verbs to add component `workflow` objects for the nuisance models.
- `fit.causal_workflow()`: An S3 method that implements cross-fitting (sample-splitting) to generate out-of-sample predictions and compute a doubly-robust AIPW estimate of the ATE.
- `predict.fitted_causal_workflow()`: An S3 method providing flexible access to the final estimate, the efficient influence function (EIF) values, and the raw nuisance component predictions.
- `tune_grid.causal_workflow()`: An S3 method for "greedy" hyperparameter tuning of individual component models.

All new functionality is accompanied by comprehensive unit tests and documentation, adhering to the project's coding standards.